### PR TITLE
🚑 Fix incremental logic to accommodate for window functions

### DIFF
--- a/models/core/_core.yml
+++ b/models/core/_core.yml
@@ -202,6 +202,8 @@ models:
         description: 'The unique order ID for the transaction.'
         tests:
           - not_null
+          - unique:
+              where: "valid_to is null"
 
       - name: takehome_percentage
         data_type: varchar

--- a/models/core/revenuecat_subscription_transactions.sql
+++ b/models/core/revenuecat_subscription_transactions.sql
@@ -17,8 +17,15 @@ source as (
         {% if var('revenuecat_filter') %}
         and {{ var('revenuecat_filter') }}
         {% endif %}
-        {% if is_incremental() %}
-        and regexp_substr(_file_name, '[0-9]{10}')::timestamp_ntz > (select max(_exported_at) from {{ this }})
+        {% if is_incremental() %} 
+        and store_transaction_id in (
+            select store_transaction_id 
+            from {{ this }} 
+            where regexp_substr(_file_name, '[0-9]{10}')::timestamp_ntz > (
+                select max(_exported_at) 
+                from {{ this }}
+            )
+        )
         {% endif %}
 
 ),

--- a/models/core/revenuecat_subscription_transactions.sql
+++ b/models/core/revenuecat_subscription_transactions.sql
@@ -22,7 +22,7 @@ source as (
     select 
         * 
     from 
-        {{ source('revenuecat', 'transactions') }} src
+        {{ source('revenuecat', 'transactions') }}
 
     where 1=1
         {% if var('revenuecat_filter') %}


### PR DESCRIPTION
This PR fixes that it's able to have multiple rows for the same `store_transaction_id` with a `valid_to is null`