### PR TITLE
✨ Support for additional v5 columns

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -14,6 +14,7 @@ log-path: "logs"
 vars:
   tasman_dbt_revenuecat:
     revenuecat_table: "SEED_REVENUECAT_TRANSACTIONS_MOCKED"
+    revenuecat_version: 5
     revenuecat_filter: "is_sandbox = false"
     revenuecat_custom_subscriber_attributes: ""
     revenuecat_mrr_test_seed: ""

--- a/models/core/revenuecat_subscription_transactions.sql
+++ b/models/core/revenuecat_subscription_transactions.sql
@@ -140,10 +140,12 @@ renamed as (
         purchase_price_in_purchased_currency,
         product_display_name,
         product_duration,
-        --offer,
-        --offer_type,
-        --first_seen_time,
-        --auto_resume_time,
+        {%- if var('revenuecat_version') > 4 %}
+        offer,
+        offer_type,
+        first_seen_time,
+        auto_resume_time,
+        {%- endif %}
 
         {%- if var('revenuecat_custom_subscriber_attributes') %}
             {%- for key, value in var('revenuecat_custom_subscriber_attributes').items() %}

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ vars:
     revenuecat_database: "source_db"
     revenuecat_schema: 'revenuecat'
     revenuecat_table: "data_export"
+    revenuecat_verson: 5
     revenuecat_filter: "is_sandbox = false"
     revenuecat_custom_subscriber_attributes: {'my_value::text': 'my_column_name'}
 ```


### PR DESCRIPTION
## Summary

This PR enables the new columns provided by RevenueCat in the [data export v5](https://www.revenuecat.com/docs/integrations/scheduled-data-exports/data-export-version-5):
- offer
- offer_type
- first_seen_time
- auto_resume_time

The variable `revenuecat_version` should be set to > 4 to enable these columns.