### PR TITLE
Grace period is already accounted for in effective end time by RC

### DIFF
--- a/models/core/revenuecat_subscription_transactions.sql
+++ b/models/core/revenuecat_subscription_transactions.sql
@@ -126,10 +126,7 @@ renamed as (
         platform,
         tax_percentage,
         commission_percentage,
-        case
-            when grace_period_end_time is not null then grace_period_end_time::timestamp_ntz
-            else effective_end_time::timestamp_ntz
-        end as effective_end_time,
+        effective_end_time::timestamp_ntz as effective_end_time,
         grace_period_end_time::timestamp_ntz as grace_period_end_time,
         grace_period_end_time is not null as is_grace_period,
         ownership_type,


### PR DESCRIPTION
The effective_end_time already takes into account the grace period.

From the documentation:
"Single reference point of a subscriber’s expiration and entitlement revocation; inclusive of each store’s logic for refunds, grace periods, etc."