### PR TITLE
Better handle PRs raised by Dependabot

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -21,11 +21,19 @@ jobs:
       SNOWFLAKE_DATABASE_CI: DBT_PACKAGE_CI
       SNOWFLAKE_ROLE_CI: PACKAGE_CI_ROLE
       SNOWFLAKE_WAREHOUSE_CI: PACKAGE_CI_WH
-      SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ github.actor }} # Creates a unique schema for each PR
     steps:
       - name: Checkout branch
         id: checkout-branch
         uses: actions/checkout@v3
+
+      - name: Set schema name
+        id: set-schema-name
+        run: |
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "schema_name=dependabot" >> $GITHUB_OUTPUT
+          else
+            echo "schema_name=${{ github.actor }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install Poetry
         id: install-poetry
@@ -51,20 +59,28 @@ jobs:
 
       - name: Check dbt compiles and CI Profiles work
         id: check-dbt-ci-profiles-work
+        env:
+          SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ steps.set-schema-name.outputs.schema_name }}
         run: |
           poetry run dbt debug --target snowflake-ci
 
       - name: dbt seed on Snowflake
         id: dbt-seed-snowflake
+        env:
+          SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ steps.set-schema-name.outputs.schema_name }}
         run: |
           poetry run dbt seed --target snowflake-ci
 
       - name: dbt run on Snowflake
         id: dbt-run-snowflake
+        env:
+          SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ steps.set-schema-name.outputs.schema_name }}
         run: |
           poetry run dbt run --full-refresh --target snowflake-ci
 
       - name: dbt test on Snowflake
         id: dbt-test-snowflake
+        env:
+          SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ steps.set-schema-name.outputs.schema_name }}
         run: |
           poetry run dbt test --target snowflake-ci

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install python deps
         id: install-python-deps
         run: |
-          poetry install
+          poetry install --no-root
 
       - name: Install dbt deps
         id: install-dbt-deps

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,174 @@
+# dbt files
+logs/
 target/
 dbt_modules/
 dbt_packages/
-logs/
-.venv
-.env
+.user.yml
+
+# System files
 .DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# VS Code
+.vscode/


### PR DESCRIPTION
## Summary

Better handle the name of the schema created by PRs raised by Dependabot.

## Details

We run dbt in CI on PRs and use the name of the git author in the newly created schema name. PRs raised by Dependabot have an author name of `dependabot[bot]` which is invalid for use in a schema name.

It's also worth mentioning here that Dependabot can't read Action secrets stored in the repo, so the repo secrets _also_ need to be added to the Dependabot secrets stored in the repo. More details at:

- https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

---

Similar PRs:

- https://github.com/TasmanAnalytics/tasman-dbt-mta/pull/43
- https://github.com/TasmanAnalytics/tasman-dbt-package-template/pull/1
- https://github.com/TasmanAnalytics/tasman-dbt-utils/pull/23